### PR TITLE
Image extension to lower case

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -1041,7 +1041,7 @@ class Image
      */
     protected function getMimeFromExtension($filename)
     {
-        $extension = pathinfo($filename, PATHINFO_EXTENSION);
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 
         switch ($extension) {
             case 'jpg':


### PR DESCRIPTION
Sometimes image extension can be uppercase and class would reject it, this resolves the problem.